### PR TITLE
check for virtualization key first before looking deeper

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,9 @@
 #
 
 # exit if running on virtualized or cloud nodes.
-return if node['virtualization']['role'] == 'guest' || node['cloud']
+return if (
+  node['virtualization'] && node['virtualization']['role'] == 'guest'
+) || node['cloud']
 
 # set appropriate service name based on platform_family
 service_name = value_for_platform_family(


### PR DESCRIPTION
This is a precaution when using this cookbook with 
chefspec, since fauxhai currently does not set
node[‘virtualization’], so the check throws.